### PR TITLE
Small code cleanups

### DIFF
--- a/src/PdfListView.js
+++ b/src/PdfListView.js
@@ -227,11 +227,11 @@ ListView.prototype = {
     },
 
     layout: function() {
-        this.savePdfPosition();
+        var positionBackup = this.getPdfPosition();
         this.containerViews.forEach(function(containerView) {
             containerView.layout();
         });
-        this.restorePdfPosition();
+        this.setPdfPosition(positionBackup);
     },
 
     getScale: function() {
@@ -350,16 +350,6 @@ ListView.prototype = {
         this.dom.scrollLeft = position.left;
     },
 
-    savePdfPosition: function() {
-        this.pdfPosition = this.getPdfPosition();
-        logger.debug("SAVED PDF POSITION", this.pdfPosition);
-    },
-
-    restorePdfPosition: function() {
-        logger.debug("RESTORING PDF POSITION", this.pdfPosition);
-        this.setPdfPosition(this.pdfPosition);
-    },
-
     getPdfPosition: function() {
         var pdfPosition = null;
         for (var i = 0; i < this.pageViews.length; i++) {
@@ -380,7 +370,7 @@ ListView.prototype = {
     },
 
     setPdfPosition: function(pdfPosition) {
-        if (typeof pdfPosition !== "undefined" && pdfPosition != null) {
+        if (pdfPosition) {
             var offset = pdfPosition.offset;
             var pageIndex = pdfPosition.page;
             var pageView = this.pageViews[pageIndex];
@@ -508,11 +498,11 @@ PageView.prototype = {
         this.isRendered = false;
         if (this.textLayerDiv) {
             this.dom.removeChild(this.textLayerDiv);
-            delete this.textLayerDiv;
+            this.textLayerDiv = null;
         }
         if (this.annotationsLayerDiv) {
             this.dom.removeChild(this.annotationsLayerDiv);
-            delete this.annotationsLayerDiv;
+            this.annotationsLayerDiv = null;
         }
     },
 
@@ -638,7 +628,7 @@ Page.prototype = {
             {
                 // The viewport changed -> need to rerender.
                 renderContext.abandon = true;
-                delete self.renderContextList[pageView.id];
+                self.renderContextList[pageView.id] = null;
                 pageView.createNewCanvas();
                 self.render(pageView, renderController);
             } else if (renderContext.state === RenderingStates.PAUSED) {


### PR DESCRIPTION
@jpallen, I think this code cleanup touches code you have written. Can you please have a look?

What I did:
1) remove the state variable `this.pdfPosition` and the associated functions `savePdfPosition()` and `restorePdfPosition()`. Handling state is evil and in this case I think the code complexity stays the same when storing the current pdfPosition in the `layout()` function in a local variable instead of a state variable on the `ListView` object
2) `if (typeof pdfPosition !== "undefined" && pdfPosition != null) {...}` can be simplified to `if (pdfPosition) {...}` I guess? Less code to read and I also think the later should be faster.
3) replaced the `delete` operator with `null` assignments. Using the `delete` operator gives JS VMs a hard time. Quoting the Google JavaScript Code Guide from [1](https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml?showone=delete#delete): 

> "In modern JavaScript engines, changing the number of properties on an object is much slower than reassigning the values. The delete keyword should be avoided except when it is necessary to remove a property from an object's iterated list of keys, or to change the result of if (key in obj)."
